### PR TITLE
게스트 로그인 또는 로그인 시  토큰 감지 시점을 뒤로 미뤄야 함.

### DIFF
--- a/lib/src/common/ui/home_screen.dart
+++ b/lib/src/common/ui/home_screen.dart
@@ -43,8 +43,10 @@ class _Home extends State<Home> {
       token = value.toString();
     });
 
+    // 토큰의 세팅이 늦게 되는 경우가 있으므로 token 의 상태를 지속적으로 감지 해야 함. 
+
     if (token == null || token == '') {
-      Future.microtask((){
+      await Future.microtask((){
         logger.i('사용자 정보를 알수 없으므로, 로그인 페이지로 이동합니다.');
           // AuthenticateState를 loadSuccess 에서 다시 돌려야 한다. 
         authenticationbloc.add(Init());

--- a/lib/src/common/util.dart
+++ b/lib/src/common/util.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:simple_month_year_picker/custom.dialog.dart';
 import 'package:simple_month_year_picker/month.container.dart';
 import 'package:simple_month_year_picker/month.model.dart';
+import 'package:theme_freight_ui/src/settings/logger.dart';
 
 class Util {
   final storage = const FlutterSecureStorage();
@@ -13,6 +14,7 @@ class Util {
   void tokenSetter(String token) async{
     storage.write(key: 'token', value: token);
     String? temp = await storage.read(key:'token');
+    logger.i('setting tkn : $temp');
   }
 
   Future<String?> tokenGetter() async {

--- a/lib/src/features/user/repository/authentication_repository.dart
+++ b/lib/src/features/user/repository/authentication_repository.dart
@@ -82,7 +82,7 @@ class AuthenticationRepositoryImpl extends AuthenticationRepository {
   @override
   Future<UserEntity> guestLogin() async {
     
-    final response = await _client.post('/api/v1/user/non-member-registration');
+    final response = await _client.geustLogin('/api/v1/user/non-member-registration');
     final status = response.statusCode;
     bool loginFlag = false;
 

--- a/lib/src/settings/client.dart
+++ b/lib/src/settings/client.dart
@@ -65,6 +65,23 @@ class APIClient {
     return res;
   }
 
+  Future<http.Response> geustLogin(String endpoint, {Object? body} ) async {
+        http.Response res = 
+    await http.post(
+      getUri(
+        endpoint,
+      ),
+      headers: {
+        'Authorization': '',
+        'Content-Type': 'application/json',
+        'accept': '*/*',
+        'Accept-Charset': 'utf-8'
+      },
+      body: body
+    );
+    return res;
+  }
+
   Future<http.Response> login(String endpoint, {Object? body, String? token} ) async {
     http.Response res = 
     await http.post(


### PR DESCRIPTION
1. 토큰이 있는 지여부를 리턴 속도보다 더 빨리 확인한다 따라서,  스토리지에 쓰기 전에 확인하기 대문에 자꾸 로그인 페이지로 다시 되돌아감